### PR TITLE
Implement Sharing Feature (Story Text Only)

### DIFF
--- a/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/controller/StoryMediaController.java
+++ b/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/controller/StoryMediaController.java
@@ -1,9 +1,13 @@
 package com.example.make_a_story_prototype.main.StoryTemplate.controller;
 
 import android.content.Context;
+import android.content.Intent;
 import android.media.MediaPlayer;
 
 import com.example.make_a_story_prototype.R;
+import com.example.make_a_story_prototype.main.Characters.view.CharacterActivity;
+import com.example.make_a_story_prototype.main.Home.view.HomeActivity;
+import com.example.make_a_story_prototype.main.StoryTemplate.view.StoryTemplateActivity;
 import com.example.make_a_story_prototype.main.StoryTemplate.vm.StoryViewModel;
 import com.example.make_a_story_prototype.main.data.Story.model.StoryBlankIdentifier;
 import com.example.make_a_story_prototype.main.data.Story.model.StoryPage;
@@ -17,14 +21,16 @@ public class StoryMediaController implements MediaPlayer.OnCompletionListener {
     private Context context;
     private StoryPage page;
     private StoryViewModel vm;
+    private boolean isLastPage;
 
     private int nextSegmentIndex;
 
-    public StoryMediaController(Context context, StoryPage page, StoryViewModel vm) {
+    public StoryMediaController(Context context, StoryPage page, StoryViewModel vm, boolean isLastPage) {
         this.context = context;
         this.page = page;
         this.vm = vm;
         this.nextSegmentIndex = 0;
+        this.isLastPage = isLastPage;
     }
 
     public void play() {
@@ -75,6 +81,10 @@ public class StoryMediaController implements MediaPlayer.OnCompletionListener {
 
     @Override
     public void onCompletion(MediaPlayer mp) {
-        playNextSegment();
+        if (isLastPage && (nextSegmentIndex >= page.getSegments().size())) {
+            vm.finishStory();
+        } else {
+            playNextSegment();
+        }
     }
 }

--- a/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/view/StoryPageView.java
+++ b/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/view/StoryPageView.java
@@ -72,7 +72,8 @@ public class StoryPageView extends ConstraintLayout implements ObservableScrollV
         mediaController = new StoryMediaController(
                 getContext(),
                 vm.getStory().getPages().get(pageNumber),
-                vm
+                vm,
+                (pageNumber == vm.getStory().getPages().size() - 1)
         );
 
         update();

--- a/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/view/StoryTemplateActivity.java
+++ b/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/view/StoryTemplateActivity.java
@@ -144,6 +144,11 @@ public class StoryTemplateActivity extends BaseActivity implements StoryViewMode
     }
 
     @Override
+    public void finishStory() {
+        startActivity(new Intent(getApplicationContext(), HomeActivity.class));
+    }
+
+    @Override
     public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
         //
     }

--- a/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/view/StoryTemplateActivity.java
+++ b/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/view/StoryTemplateActivity.java
@@ -4,9 +4,10 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.PersistableBundle;
-import android.util.Log;
+import android.text.SpannableStringBuilder;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -152,18 +153,44 @@ public class StoryTemplateActivity extends BaseActivity implements StoryViewMode
 
     private void showShareDialogue() {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        // Add the buttons
+
+        // share button allows the user to share story text
+        //TODO: allow user to share story images
         builder.setPositiveButton("Share", new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
-                Toast.makeText(getApplicationContext(), "share button clicked", Toast.LENGTH_SHORT).show();
+
+                // creating email intent with type
+                Intent emailIntent = new Intent(android.content.Intent.ACTION_SEND);
+                emailIntent.setType("application/image");
+                String storyText = "";
+
+                for (int i = 0; i < vm.getStory().getPages().size(); i++) {
+                    //fetching story text based on pages
+                    SpannableStringBuilder pageText = (SpannableStringBuilder) (vm.getTextForPage(i));
+                    storyText = storyText + pageText.toString();
+
+                    //fetching story image based on pages
+//                    Uri path = Uri.parse("android.resource://com.example.make_a_story_prototype/" +
+//                            vm.getStory().getPages().get(i).getImageResource());
+//                    String imgPath = path.toString();
+//                    emailIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse(imgPath));
+                }
+
+                // extra attributes to the email including subject and content text
+                emailIntent.putExtra(android.content.Intent.EXTRA_SUBJECT,"Brainy Make-A-Story Android: Completed Story Template");
+                emailIntent.putExtra(android.content.Intent.EXTRA_TEXT, vm.getStory().getTitle() + "\n\n" + storyText);
+                startActivity(Intent.createChooser(emailIntent, "Choose an Email client :"));
             }
         });
+
+        //cancel button directs user to home page with selections cleared
         builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
                 vm.clearSelections();
                 startActivity(new Intent(getApplicationContext(), HomeActivity.class));
             }
         });
+
         // Create the AlertDialog
         AlertDialog dialog = builder.create();
         dialog.setMessage("Congratulations! You finished the story.\nDo you want to share the completed story?");

--- a/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/view/StoryTemplateActivity.java
+++ b/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/view/StoryTemplateActivity.java
@@ -1,6 +1,8 @@
 package com.example.make_a_story_prototype.main.StoryTemplate.view;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.PersistableBundle;
@@ -145,7 +147,28 @@ public class StoryTemplateActivity extends BaseActivity implements StoryViewMode
 
     @Override
     public void finishStory() {
-        startActivity(new Intent(getApplicationContext(), HomeActivity.class));
+        showShareDialogue();
+    }
+
+    private void showShareDialogue() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        // Add the buttons
+        builder.setPositiveButton("Share", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+                Toast.makeText(getApplicationContext(), "share button clicked", Toast.LENGTH_SHORT).show();
+            }
+        });
+        builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+                vm.clearSelections();
+                startActivity(new Intent(getApplicationContext(), HomeActivity.class));
+            }
+        });
+        // Create the AlertDialog
+        AlertDialog dialog = builder.create();
+        dialog.setMessage("Congratulations! You finished the story.\nDo you want to share the completed story?");
+        dialog.setCanceledOnTouchOutside(false);
+        dialog.show();
     }
 
     @Override

--- a/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/vm/StoryViewModel.java
+++ b/prototype/app/src/main/java/com/example/make_a_story_prototype/main/StoryTemplate/vm/StoryViewModel.java
@@ -30,6 +30,7 @@ public class StoryViewModel implements Parcelable {
 
     public interface StoryViewModelCallback {
         void onSelectedBlank(String identifier);
+        void finishStory();
     }
 
     private StoryRepository storyRepository = DebugStoryRepository.getInstance();
@@ -111,6 +112,14 @@ public class StoryViewModel implements Parcelable {
         }
 
         callback.onSelectedBlank(identifier);
+    }
+
+    public void finishStory() {
+        if (callback == null) {
+            return;
+        }
+
+        callback.finishStory();
     }
 
     @Override


### PR DESCRIPTION
When reaching the end of audio on the last page of the story, an alert would pop up that allows the user to share the completed story. The alert has the following 2 buttons:

"cancel" - takes the user to the home page. all selections are cleared.
"share" - allows the user to choose an external app (currently the user can choose anything, not just email). The app would automatically construct the completed story text and add it to the message. However, story images sharing is not yet implemented.